### PR TITLE
Problem: Go Cmd args expects the command being run

### DIFF
--- a/cmd/wrapper.go
+++ b/cmd/wrapper.go
@@ -251,8 +251,9 @@ func wrapCmd(cmd *cobra.Command, args []string) error {
 		log.Printf("Got message from riker: %+v\n", msg)
 		cmdArgs := segmentMessage(namespace, msg.Payload)
 
-		fullArgs := args[1:]
-		fullArgs = append(fullArgs, cmdArgs...)
+		// ensure we take the command to run + cli args and then add any args passed
+		// from chat
+		fullArgs := append(args, cmdArgs...)
 
 		reply := &botpb.Message{
 			Channel:   msg.Channel,


### PR DESCRIPTION
Solution: add it to the args when constructing the command


per the go docs
```
        // Args holds command line arguments, including the command as Args[0].
        // If the Args field is empty or nil, Run uses {Path}.
        //
        // In typical use, both Path and Args are set by calling Command.
        Args []string
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pantheon-systems/redshirt-cli-wrapper/5)
<!-- Reviewable:end -->
