### PR TITLE
adding in the ability to pass the calling group and user nickname as env vars to the script

### DIFF
--- a/cmd/wrapper.go
+++ b/cmd/wrapper.go
@@ -278,6 +278,10 @@ func wrapCmd(cmd *cobra.Command, args []string) error {
 		c := exec.Cmd{
 			Path: args[0],
 			Args: fullArgs,
+			Env: []string{
+				"RIKER_GROUP=(" + strings.Join(msg.Groups, " ") + ")",
+				"RIKER_NICKNAME=" + msg.Nickname,
+			},
 		}
 
 		go runCmd(reply, c)

--- a/cmd/wrapper.go
+++ b/cmd/wrapper.go
@@ -279,7 +279,7 @@ func wrapCmd(cmd *cobra.Command, args []string) error {
 			Path: args[0],
 			Args: fullArgs,
 			Env: []string{
-				"RIKER_GROUP=(" + strings.Join(msg.Groups, " ") + ")",
+				"RIKER_GROUP=" + strings.Join(msg.Groups, ","),
 				"RIKER_NICKNAME=" + msg.Nickname,
 			},
 		}


### PR DESCRIPTION
Problem: I want to know the group and nickname of the calling user inside a redshirt wrapped with this wrapper


Solution: Expose them as env vars to the wrapped script